### PR TITLE
feat: 事業ノードの支出先タブ実装

### DIFF
--- a/src/components/BudgetFlowMap.tsx
+++ b/src/components/BudgetFlowMap.tsx
@@ -269,6 +269,7 @@ export function BudgetFlowMap() {
       {/* Side Panel on left (integrated search + info) */}
       <SidePanel
         nodes={scaledData.nodes}
+        edges={scaledData.edges}
         onNodeSelect={handleSearchSelect}
       />
       {/* Main content area */}

--- a/src/components/InfoPanel/RecipientsTab.tsx
+++ b/src/components/InfoPanel/RecipientsTab.tsx
@@ -1,13 +1,46 @@
-import type { LayoutNode } from '@/types/layout'
+import { useMemo } from 'react'
+import type { LayoutNode, LayoutEdge } from '@/types/layout'
+import { formatAmount } from '@/utils/formatAmount'
 
 interface RecipientsTabProps {
   node: LayoutNode
+  edges: LayoutEdge[]
+  nodes: LayoutNode[]
 }
 
-export function RecipientsTab({ node }: RecipientsTabProps) {
-  // This tab will show related recipients for project nodes
-  // For now, show placeholder content
+interface RecipientWithAmount {
+  node: LayoutNode
+  amount: number
+}
 
+export function RecipientsTab({ node, edges, nodes }: RecipientsTabProps) {
+  // この事業から支出先への接続を検索
+  const recipients = useMemo((): RecipientWithAmount[] => {
+    // 事業ノード以外は空配列を返す
+    if (node.type !== 'project') {
+      return []
+    }
+
+    // この事業ノードからの出エッジを取得
+    const outgoingEdges = edges.filter(edge => edge.sourceId === node.id)
+
+    // エッジから支出先ノードと金額を取得
+    const recipientList: RecipientWithAmount[] = []
+    for (const edge of outgoingEdges) {
+      const recipientNode = nodes.find(n => n.id === edge.targetId)
+      if (recipientNode && recipientNode.type === 'recipient') {
+        recipientList.push({
+          node: recipientNode,
+          amount: edge.value
+        })
+      }
+    }
+
+    // 金額降順でソート
+    return recipientList.sort((a, b) => b.amount - a.amount)
+  }, [node.id, node.type, edges, nodes])
+
+  // 事業ノード以外は表示しない
   if (node.type !== 'project') {
     return (
       <div className="text-slate-400 text-center py-8">
@@ -16,19 +49,97 @@ export function RecipientsTab({ node }: RecipientsTabProps) {
     )
   }
 
+  if (recipients.length === 0) {
+    return (
+      <div className="text-slate-400 text-center py-8">
+        <p className="text-sm">この事業には支出先データがありません</p>
+      </div>
+    )
+  }
+
+  // 合計金額
+  const totalAmount = recipients.reduce((sum, r) => sum + r.amount, 0)
+
   return (
     <div className="space-y-4">
-      <p className="text-slate-400 text-sm">
-        この事業に関連する支出先の一覧
-      </p>
-
-      {/* Placeholder - will be populated when we have edge data accessible */}
-      <div className="text-slate-500 text-center py-8 border border-dashed border-slate-600 rounded">
-        <p className="text-sm">支出先データを読み込み中...</p>
-        <p className="text-xs mt-2">
-          (実装予定: レイアウトデータから接続された支出先ノードを表示)
-        </p>
+      {/* Summary */}
+      <div className="bg-slate-700/50 border border-slate-600 rounded-lg p-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-slate-400">支出先総数</span>
+          <span className="text-lg font-semibold text-white">{recipients.length.toLocaleString()}件</span>
+        </div>
+        <div className="flex items-center justify-between mt-2">
+          <span className="text-sm text-slate-400">合計支出額</span>
+          <span className="text-lg font-semibold text-white">{formatAmount(totalAmount)}</span>
+        </div>
       </div>
+
+      {/* Recipients list */}
+      <div>
+        <h3 className="text-xs font-medium text-slate-500 uppercase tracking-wide mb-2">
+          支出先一覧
+        </h3>
+        <div className="space-y-2">
+          {recipients.map(({ node: recipientNode, amount }, index) => {
+            const percentage = (amount / totalAmount) * 100
+            return (
+              <div
+                key={recipientNode.id}
+                className="bg-slate-700/30 border border-slate-600/50 rounded-lg p-3 hover:bg-slate-700/50 transition-colors"
+              >
+                {/* Rank and name */}
+                <div className="flex items-start gap-2 mb-2">
+                  <span className="text-xs font-medium text-slate-500 mt-0.5">#{index + 1}</span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-white truncate">
+                      {recipientNode.name}
+                    </p>
+                    {recipientNode.metadata.corporateType && (
+                      <p className="text-xs text-slate-400 mt-0.5">
+                        {recipientNode.metadata.corporateType}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Amount and percentage */}
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-semibold text-blue-300">
+                    {formatAmount(amount)}
+                  </span>
+                  <span className="text-xs text-slate-400">
+                    {percentage.toFixed(1)}%
+                  </span>
+                </div>
+
+                {/* Progress bar */}
+                <div className="w-full bg-slate-600 rounded-full h-1.5">
+                  <div
+                    className="bg-blue-500 h-1.5 rounded-full transition-all"
+                    style={{ width: `${Math.min(percentage, 100)}%` }}
+                  />
+                </div>
+
+                {/* Additional info */}
+                {recipientNode.metadata.location && (
+                  <p className="text-xs text-slate-500 mt-2 truncate">
+                    📍 {recipientNode.metadata.location}
+                  </p>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Note about multiple ministries */}
+      {recipients.some(r => r.node.metadata.sourceMinistries && r.node.metadata.sourceMinistries.length > 1) && (
+        <div className="bg-blue-900/20 border border-blue-700/30 rounded-lg p-3">
+          <p className="text-xs text-blue-300">
+            💡 一部の支出先は複数の府省庁から支出を受けています
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -3,15 +3,16 @@ import { useStore } from '@/store'
 import { BasicInfoTab } from './InfoPanel/BasicInfoTab'
 import { RecipientsTab } from './InfoPanel/RecipientsTab'
 import { FlowContextTab } from './InfoPanel/FlowContextTab'
-import type { LayoutNode } from '@/types/layout'
+import type { LayoutNode, LayoutEdge } from '@/types/layout'
 import type { InfoPanelTab } from '@/types/store'
 
 interface SidePanelProps {
   nodes: LayoutNode[]
+  edges: LayoutEdge[]
   onNodeSelect: (node: LayoutNode) => void
 }
 
-export function SidePanel({ nodes, onNodeSelect }: SidePanelProps) {
+export function SidePanel({ nodes, edges, onNodeSelect }: SidePanelProps) {
   const selectedNode = useStore((state) => state.selectedNodeData)
   const activeTab = useStore((state) => state.activeTab)
   const setActiveTab = useStore((state) => state.setActiveTab)
@@ -254,7 +255,7 @@ export function SidePanel({ nodes, onNodeSelect }: SidePanelProps) {
           {/* Tab content */}
           <div className="flex-1 overflow-auto p-4">
             {activeTab === 'basic' && <BasicInfoTab node={selectedNode} />}
-            {activeTab === 'recipients' && <RecipientsTab node={selectedNode} />}
+            {activeTab === 'recipients' && <RecipientsTab node={selectedNode} edges={edges} nodes={nodes} />}
             {activeTab === 'flow' && <FlowContextTab node={selectedNode} />}
           </div>
         </>


### PR DESCRIPTION
## Summary

事業ノードをクリックしたときの「支出先」タブを実装しました。エッジデータから接続された支出先ノードを取得し、金額降順でリスト表示します。

## 主な変更点

### 1. RecipientsTab実装

- **支出先一覧表示**
  - エッジデータから事業ノードに接続された支出先を自動検出
  - 金額降順でソート、ランキング形式で表示
  - 各支出先の金額とパーセンテージを表示
  - プログレスバーで視覚的に割合を表示

- **詳細情報**
  - 法人種別（地方公共団体、株式会社など）
  - 所在地（📍アイコン付き）
  - 支出先総数と合計支出額のサマリー

- **UI/UX改善**
  - カード式のリスト表示
  - ホバー時の背景色変化
  - 複数府省庁から支出を受けている場合の注記

### 2. データフロー改善

```
BudgetFlowMap 
  → SidePanel (edges + nodes を渡す)
    → RecipientsTab
      - useMemo でエッジから支出先を検索
      - 金額降順でソート
      - 表示
```

## スクリーンショット

（実際の動作画面）
- 事業ノードをクリック → 「支出先」タブを開く
- 支出先一覧が金額降順で表示される
- 各支出先の詳細情報（法人種別、所在地、金額、割合）が表示される

## Test plan

- [x] 事業ノードをクリックして「支出先」タブを開く
- [x] 支出先一覧が金額降順で表示されることを確認
- [x] サマリー（支出先総数、合計支出額）が正しく表示されることを確認
- [x] 法人種別・所在地などのメタデータが正しく表示されることを確認
- [x] プログレスバーの幅が正しく計算されることを確認
- [x] 事業ノード以外（府省・局・課・支出先）では適切なメッセージが表示されることを確認
- [x] Lintチェックが通ることを確認
- [x] Buildが成功することを確認

## 関連Issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recipients tab now displays actual data instead of placeholder content, including total recipients and total spend summaries.
  * Detailed recipient list with ranking, amounts, percentage breakdowns, locations, and ministry notes.
  * Automatic filtering and sorting of recipients by amount in descending order.
  * Contextual messaging for cases with no recipients or multiple source ministries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->