### PR TITLE
feat: 左パネルUX改善 - タイトルツールチップ、階層パス改行、コンパクト表示

### DIFF
--- a/src/components/BudgetFlowMap.tsx
+++ b/src/components/BudgetFlowMap.tsx
@@ -94,24 +94,6 @@ export function BudgetFlowMap() {
     animationRef.current = requestAnimationFrame(animate)
   }, [])
 
-  // Initial load: select node from URL
-  useEffect(() => {
-    if (!data || initialUrlLoadRef.current) return
-
-    const nodeId = getNodeIdFromUrl()
-    if (nodeId) {
-      const node = data.nodes.find(n => n.id === nodeId)
-      if (node) {
-        setSelectedNode(nodeId, node)
-        // Navigate to node
-        const targetZoom = -2
-        animateTo(node.x, node.y, targetZoom, 800)
-      }
-    }
-
-    initialUrlLoadRef.current = true
-  }, [data, setSelectedNode, animateTo])
-
   // Update URL when node selection changes (include node name for readability)
   useEffect(() => {
     if (initialUrlLoadRef.current) {
@@ -256,14 +238,30 @@ export function BudgetFlowMap() {
     const zoomY = Math.log2(viewportHeight / (boundsHeight * padding))
     const fitZoom = Math.min(zoomX, zoomY)
 
-    // Reset view state to center with calculated zoom
-    setViewState({
-      target: [centerX, centerY],
-      zoom: fitZoom,
-      minZoom: -13,
-      maxZoom: 6,
-    })
-  }, [scaledData])
+    // Animate to fit position
+    animateTo(centerX, centerY, fitZoom, 800)
+  }, [scaledData, animateTo])
+
+  // Initial load: select node from URL or fit to screen
+  useEffect(() => {
+    if (!scaledData || initialUrlLoadRef.current) return
+
+    const nodeId = getNodeIdFromUrl()
+    if (nodeId) {
+      const node = scaledData.nodes.find(n => n.id === nodeId)
+      if (node) {
+        setSelectedNode(nodeId, node)
+        // Navigate to node
+        const targetZoom = -2
+        animateTo(node.x, node.y, targetZoom, 800)
+      }
+    } else {
+      // No node selected, fit to screen with animation
+      handleFitToScreen()
+    }
+
+    initialUrlLoadRef.current = true
+  }, [scaledData, setSelectedNode, animateTo, handleFitToScreen])
 
   if (loading) {
     return (

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -157,11 +157,9 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
   const showPanel = query.trim() || selectedNode
 
   return (
-    <aside className={`h-full bg-slate-800 shadow-lg flex flex-col z-10 border-r border-slate-700 shrink-0 transition-all duration-200 ${
-      showPanel ? 'w-96' : 'w-80'
-    }`}>
-      {/* Search bar - always visible */}
-      <div className="p-3 border-b border-slate-700">
+    <div className="relative h-full z-10">
+      {/* Search box - always visible, floating */}
+      <div className="absolute top-3 left-3 z-20">
         <div className="relative">
           <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -173,7 +171,7 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="ノード名で検索... (⌘K)"
-            className="w-full bg-slate-700 text-white pl-10 pr-10 py-2 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-80 bg-slate-800 text-white pl-10 pr-10 py-2 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 shadow-lg border border-slate-700"
           />
           {query && (
             <button
@@ -188,147 +186,151 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
         </div>
       </div>
 
-      {/* Search results (when query exists) */}
-      {query.trim() && (
-        <div ref={listRef} className="overflow-y-auto flex-1 border-b border-slate-700">
-          {searchResults.length === 0 ? (
-            <div className="p-4 text-center text-slate-400 text-sm">
-              「{query}」に一致するノードが見つかりません
+      {/* Panel - only show when searching or node selected */}
+      {showPanel && (
+        <aside className="absolute top-0 left-0 w-96 h-full bg-slate-800 shadow-lg flex flex-col border-r border-slate-700">
+          {/* Search results (when query exists) */}
+          {query.trim() && (
+            <div ref={listRef} className="overflow-y-auto flex-1 border-b border-slate-700">
+              {searchResults.length === 0 ? (
+                <div className="p-4 text-center text-slate-400 text-sm">
+                  「{query}」に一致するノードが見つかりません
+                </div>
+              ) : (
+                <>
+                  {searchResults.map((node, index) => (
+                    <button
+                      key={node.id}
+                      onClick={() => handleNodeSelect(node)}
+                      className={`w-full px-4 py-3 text-left hover:bg-slate-700 flex flex-col gap-1 border-b border-slate-700/50 ${
+                        index === selectedIndex ? 'bg-slate-700' : ''
+                      }`}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className={`text-xs px-1.5 py-0.5 rounded ${
+                          node.layer === 0 ? 'bg-cyan-600/50 text-cyan-200' :
+                          node.layer === 1 ? 'bg-blue-600/50 text-blue-200' :
+                          node.layer === 2 ? 'bg-green-600/50 text-green-200' :
+                          node.layer === 3 ? 'bg-yellow-600/50 text-yellow-200' :
+                          'bg-red-600/50 text-red-200'
+                        }`}>
+                          {getLayerName(node.layer)}
+                        </span>
+                        <span className="text-white text-sm truncate flex-1">{node.name}</span>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs text-slate-400">
+                        <span>{formatAmount(node.amount)}</span>
+                        {node.ministryId && node.layer > 0 && (
+                          <span className="truncate">・{node.ministryId}</span>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                  <div className="p-2 text-xs text-slate-500 flex items-center justify-between">
+                    <span>↑↓ 選択 Enter 決定 Esc 閉じる</span>
+                    <span>{searchResults.length}件</span>
+                  </div>
+                </>
+              )}
             </div>
-          ) : (
+          )}
+
+          {/* Node details (when selected and not searching) */}
+          {selectedNode && !query.trim() && (
             <>
-              {searchResults.map((node, index) => (
-                <button
-                  key={node.id}
-                  onClick={() => handleNodeSelect(node)}
-                  className={`w-full px-4 py-3 text-left hover:bg-slate-700 flex flex-col gap-1 border-b border-slate-700/50 ${
-                    index === selectedIndex ? 'bg-slate-700' : ''
-                  }`}
-                >
-                  <div className="flex items-center gap-2">
-                    <span className={`text-xs px-1.5 py-0.5 rounded ${
-                      node.layer === 0 ? 'bg-cyan-600/50 text-cyan-200' :
-                      node.layer === 1 ? 'bg-blue-600/50 text-blue-200' :
-                      node.layer === 2 ? 'bg-green-600/50 text-green-200' :
-                      node.layer === 3 ? 'bg-yellow-600/50 text-yellow-200' :
-                      'bg-red-600/50 text-red-200'
-                    }`}>
-                      {getLayerName(node.layer)}
-                    </span>
-                    <span className="text-white text-sm truncate flex-1">{node.name}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-xs text-slate-400">
-                    <span>{formatAmount(node.amount)}</span>
-                    {node.ministryId && node.layer > 0 && (
-                      <span className="truncate">・{node.ministryId}</span>
+              {/* Header with export and close buttons */}
+              <header className="p-4 border-b border-slate-700 flex justify-between items-start">
+                <div className="flex-1 min-w-0">
+                  <h2 className="text-lg font-semibold text-white truncate" title={selectedNode.name}>
+                    {selectedNode.name}
+                  </h2>
+                  {/* Hierarchy path or corporate type */}
+                  {selectedNode.type === 'recipient' ? (
+                    <p className="text-sm text-slate-400 mt-1">
+                      {selectedNode.metadata.corporateType || '分類なし'}
+                    </p>
+                  ) : selectedNode.metadata.hierarchyPath && selectedNode.metadata.hierarchyPath.length > 0 ? (
+                    <p className="text-sm text-slate-400 mt-1 break-words">
+                      {selectedNode.metadata.hierarchyPath.map((path, index) => (
+                        <span key={index} className="inline-block">
+                          {index > 0 && <span className="mx-1">→</span>}
+                          <span>{path}</span>
+                        </span>
+                      ))}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={handleShare}
+                    className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors relative"
+                    aria-label="リンクをコピー"
+                    title="リンクをコピー"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+                    </svg>
+                    {showCopySuccess && (
+                      <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-green-600 text-white text-xs rounded whitespace-nowrap">
+                        コピーしました
+                      </span>
                     )}
-                  </div>
-                </button>
-              ))}
-              <div className="p-2 text-xs text-slate-500 flex items-center justify-between">
-                <span>↑↓ 選択 Enter 決定 Esc 閉じる</span>
-                <span>{searchResults.length}件</span>
+                  </button>
+                  <button
+                    onClick={() => exportNodeToCsv(selectedNode, rawEdges, rawNodes)}
+                    className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors"
+                    aria-label="CSVエクスポート"
+                    title="CSVエクスポート"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={clearSelection}
+                    className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors"
+                    aria-label="閉じる"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
+              </header>
+
+              {/* Tab navigation */}
+              <nav className="flex border-b border-slate-700">
+                {tabs.map((tab) => (
+                  <button
+                    key={tab.key}
+                    className={`flex-1 py-3 text-sm font-medium transition-colors ${
+                      activeTab === tab.key
+                        ? 'text-blue-400 border-b-2 border-blue-400'
+                        : 'text-slate-400 hover:text-slate-200'
+                    }`}
+                    onClick={() => setActiveTab(tab.key)}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </nav>
+
+              {/* Tab content */}
+              <div className="flex-1 overflow-auto p-4">
+                {activeTab === 'basic' && <BasicInfoTab node={selectedNode} />}
+                {activeTab === 'recipients' && (
+                  selectedNode.type === 'recipient' ? (
+                    <ProjectsTab node={selectedNode} edges={edges} nodes={nodes} rawNodes={rawNodes} rawEdges={rawEdges} />
+                  ) : (
+                    <RecipientsTab node={selectedNode} edges={edges} nodes={nodes} rawNodes={rawNodes} rawEdges={rawEdges} />
+                  )
+                )}
+                {activeTab === 'flow' && <FlowContextTab node={selectedNode} edges={edges} nodes={nodes} rawNodes={rawNodes} rawEdges={rawEdges} />}
               </div>
             </>
           )}
-        </div>
+        </aside>
       )}
-
-      {/* Node details (when selected and not searching) */}
-      {selectedNode && !query.trim() && (
-        <>
-          {/* Header with export and close buttons */}
-          <header className="p-4 border-b border-slate-700 flex justify-between items-start">
-            <div className="flex-1 min-w-0">
-              <h2 className="text-lg font-semibold text-white truncate" title={selectedNode.name}>
-                {selectedNode.name}
-              </h2>
-              {/* Hierarchy path or corporate type */}
-              {selectedNode.type === 'recipient' ? (
-                <p className="text-sm text-slate-400 mt-1">
-                  {selectedNode.metadata.corporateType || '分類なし'}
-                </p>
-              ) : selectedNode.metadata.hierarchyPath && selectedNode.metadata.hierarchyPath.length > 0 ? (
-                <p className="text-sm text-slate-400 mt-1 break-words">
-                  {selectedNode.metadata.hierarchyPath.map((path, index) => (
-                    <span key={index} className="inline-block">
-                      {index > 0 && <span className="mx-1">→</span>}
-                      <span>{path}</span>
-                    </span>
-                  ))}
-                </p>
-              ) : null}
-            </div>
-            <div className="flex items-center gap-1">
-              <button
-                onClick={handleShare}
-                className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors relative"
-                aria-label="リンクをコピー"
-                title="リンクをコピー"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
-                </svg>
-                {showCopySuccess && (
-                  <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-green-600 text-white text-xs rounded whitespace-nowrap">
-                    コピーしました
-                  </span>
-                )}
-              </button>
-              <button
-                onClick={() => exportNodeToCsv(selectedNode, rawEdges, rawNodes)}
-                className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors"
-                aria-label="CSVエクスポート"
-                title="CSVエクスポート"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-                </svg>
-              </button>
-              <button
-                onClick={clearSelection}
-                className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-700 rounded transition-colors"
-                aria-label="閉じる"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-          </header>
-
-          {/* Tab navigation */}
-          <nav className="flex border-b border-slate-700">
-            {tabs.map((tab) => (
-              <button
-                key={tab.key}
-                className={`flex-1 py-3 text-sm font-medium transition-colors ${
-                  activeTab === tab.key
-                    ? 'text-blue-400 border-b-2 border-blue-400'
-                    : 'text-slate-400 hover:text-slate-200'
-                }`}
-                onClick={() => setActiveTab(tab.key)}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </nav>
-
-          {/* Tab content */}
-          <div className="flex-1 overflow-auto p-4">
-            {activeTab === 'basic' && <BasicInfoTab node={selectedNode} />}
-            {activeTab === 'recipients' && (
-              selectedNode.type === 'recipient' ? (
-                <ProjectsTab node={selectedNode} edges={edges} nodes={nodes} rawNodes={rawNodes} rawEdges={rawEdges} />
-              ) : (
-                <RecipientsTab node={selectedNode} edges={edges} nodes={nodes} rawNodes={rawNodes} rawEdges={rawEdges} />
-              )
-            )}
-            {activeTab === 'flow' && <FlowContextTab node={selectedNode} edges={edges} nodes={nodes} rawNodes={rawNodes} rawEdges={rawEdges} />}
-          </div>
-        </>
-      )}
-
-    </aside>
+    </div>
   )
 }

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -26,6 +26,7 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [showCopySuccess, setShowCopySuccess] = useState(false)
+  const [isCollapsed, setIsCollapsed] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
 
@@ -99,6 +100,7 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
   const handleNodeSelect = useCallback((node: LayoutNode) => {
     onNodeSelect(node)
     setQuery('')
+    setIsCollapsed(false) // Auto-expand when node is selected
   }, [onNodeSelect])
 
   // Handle keyboard navigation
@@ -154,12 +156,31 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
     ]
   }, [selectedNode?.type])
 
-  const showPanel = query.trim() || selectedNode
+  const showPanel = !isCollapsed && (query.trim() || selectedNode)
 
   return (
     <div className="relative h-full z-10">
-      {/* Search box - always visible, floating */}
-      <div className="absolute top-3 left-3 z-20">
+      {/* Toggle button - always visible */}
+      <button
+        onClick={() => setIsCollapsed(!isCollapsed)}
+        className="absolute top-3 left-3 z-30 p-2 bg-slate-800 text-white rounded-lg shadow-lg border border-slate-700 hover:bg-slate-700 transition-colors"
+        aria-label={isCollapsed ? 'サイドパネルを展開する' : 'サイドパネルを折りたたむ'}
+        title={isCollapsed ? 'サイドパネルを展開する' : 'サイドパネルを折りたたむ'}
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          {isCollapsed ? (
+            // Expand icon (chevron right)
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          ) : (
+            // Collapse icon (chevron left)
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          )}
+        </svg>
+      </button>
+
+      {/* Search box - visible when expanded */}
+      {!isCollapsed && (
+        <div className="absolute top-3 left-14 z-20">
         <div className="relative">
           <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -184,7 +205,8 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
             </button>
           )}
         </div>
-      </div>
+        </div>
+      )}
 
       {/* Panel - only show when searching or node selected */}
       {showPanel && (

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -22,11 +22,12 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
   const activeTab = useStore((state) => state.activeTab)
   const setActiveTab = useStore((state) => state.setActiveTab)
   const clearSelection = useStore((state) => state.clearSelection)
+  const isCollapsed = useStore((state) => state.isPanelCollapsed)
+  const setPanelCollapsed = useStore((state) => state.setPanelCollapsed)
 
   const [query, setQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [showCopySuccess, setShowCopySuccess] = useState(false)
-  const [isCollapsed, setIsCollapsed] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
 
@@ -100,7 +101,7 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
   const handleNodeSelect = useCallback((node: LayoutNode) => {
     onNodeSelect(node)
     setQuery('')
-    setIsCollapsed(false) // Auto-expand when node is selected
+    // Auto-expand is now handled in Zustand store's setSelectedNode
   }, [onNodeSelect])
 
   // Handle keyboard navigation
@@ -160,27 +161,9 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
 
   return (
     <div className="relative h-full z-10">
-      {/* Toggle button - always visible */}
-      <button
-        onClick={() => setIsCollapsed(!isCollapsed)}
-        className="absolute top-3 left-3 z-30 p-2 bg-slate-800 text-white rounded-lg shadow-lg border border-slate-700 hover:bg-slate-700 transition-colors"
-        aria-label={isCollapsed ? 'サイドパネルを展開する' : 'サイドパネルを折りたたむ'}
-        title={isCollapsed ? 'サイドパネルを展開する' : 'サイドパネルを折りたたむ'}
-      >
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          {isCollapsed ? (
-            // Expand icon (chevron right)
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-          ) : (
-            // Collapse icon (chevron left)
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-          )}
-        </svg>
-      </button>
-
       {/* Search box - visible when expanded */}
       {!isCollapsed && (
-        <div className="absolute top-3 left-14 z-20">
+        <div className="absolute top-3 left-3 z-20">
         <div className="relative">
           <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -211,6 +194,17 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
       {/* Panel - only show when searching or node selected */}
       {showPanel && (
         <aside className="absolute top-0 left-0 w-96 h-full bg-slate-800 shadow-lg flex flex-col border-r border-slate-700">
+          {/* Toggle button - on the right edge of panel, vertically centered */}
+          <button
+            onClick={() => setPanelCollapsed(true)}
+            className="absolute top-1/2 -translate-y-1/2 -right-4 z-30 p-2 bg-slate-800 text-white rounded-r-lg shadow-lg border border-slate-700 hover:bg-slate-700 transition-colors"
+            aria-label="サイドパネルを折りたたむ"
+            title="サイドパネルを折りたたむ"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
           {/* Search results (when query exists) */}
           {query.trim() && (
             <div ref={listRef} className="overflow-y-auto flex-1 border-b border-slate-700 pt-16">

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -161,15 +161,15 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
 
   return (
     <div className="relative h-full z-10">
-      {/* Expand button - visible when collapsed */}
+      {/* Expand button - visible when collapsed, edge style */}
       {isCollapsed && (
         <button
           onClick={() => setPanelCollapsed(false)}
-          className="absolute top-3 left-3 z-30 p-2 bg-slate-800 text-white rounded-lg shadow-lg border border-slate-700 hover:bg-slate-700 transition-colors"
+          className="absolute top-1/2 -translate-y-1/2 left-0 z-30 w-1.5 h-12 bg-slate-800 text-white rounded-r-md shadow-lg border-r border-t border-b border-slate-700 hover:bg-slate-700 transition-colors flex items-center justify-center"
           aria-label="サイドパネルを展開する"
           title="サイドパネルを展開する"
         >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
           </svg>
         </button>
@@ -208,14 +208,14 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
       {/* Panel - only show when searching or node selected */}
       {showPanel && (
         <aside className="absolute top-0 left-0 w-96 h-full bg-slate-800 shadow-lg flex flex-col border-r border-slate-700">
-          {/* Toggle button - on the right edge of panel, vertically centered */}
+          {/* Collapse button - on the right edge of panel, vertically centered, edge style */}
           <button
             onClick={() => setPanelCollapsed(true)}
-            className="absolute top-1/2 -translate-y-1/2 -right-4 z-30 p-2 bg-slate-800 text-white rounded-r-lg shadow-lg border border-slate-700 hover:bg-slate-700 transition-colors"
+            className="absolute top-1/2 -translate-y-1/2 right-0 z-30 w-1.5 h-12 bg-slate-800 text-white rounded-r-md shadow-lg border-r border-t border-b border-slate-700 hover:bg-slate-700 transition-colors flex items-center justify-center"
             aria-label="サイドパネルを折りたたむ"
             title="サイドパネルを折りたたむ"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
           </button>

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -191,7 +191,7 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
         <aside className="absolute top-0 left-0 w-96 h-full bg-slate-800 shadow-lg flex flex-col border-r border-slate-700">
           {/* Search results (when query exists) */}
           {query.trim() && (
-            <div ref={listRef} className="overflow-y-auto flex-1 border-b border-slate-700">
+            <div ref={listRef} className="overflow-y-auto flex-1 border-b border-slate-700 pt-16">
               {searchResults.length === 0 ? (
                 <div className="p-4 text-center text-slate-400 text-sm">
                   「{query}」に一致するノードが見つかりません
@@ -239,7 +239,7 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
           {selectedNode && !query.trim() && (
             <>
               {/* Header with export and close buttons */}
-              <header className="p-4 border-b border-slate-700 flex justify-between items-start">
+              <header className="p-4 pt-16 border-b border-slate-700 flex justify-between items-start">
                 <div className="flex-1 min-w-0">
                   <h2 className="text-lg font-semibold text-white truncate" title={selectedNode.name}>
                     {selectedNode.name}

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -161,6 +161,20 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
 
   return (
     <div className="relative h-full z-10">
+      {/* Expand button - visible when collapsed */}
+      {isCollapsed && (
+        <button
+          onClick={() => setPanelCollapsed(false)}
+          className="absolute top-3 left-3 z-30 p-2 bg-slate-800 text-white rounded-lg shadow-lg border border-slate-700 hover:bg-slate-700 transition-colors"
+          aria-label="サイドパネルを展開する"
+          title="サイドパネルを展開する"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      )}
+
       {/* Search box - visible when expanded */}
       {!isCollapsed && (
         <div className="absolute top-3 left-3 z-20">

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -271,7 +271,7 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
                     </svg>
                     {showCopySuccess && (
-                      <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-green-600 text-white text-xs rounded whitespace-nowrap">
+                      <span className="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-green-600 text-white text-xs rounded whitespace-nowrap z-50">
                         コピーしました
                       </span>
                     )}

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -165,7 +165,7 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
       {isCollapsed && (
         <button
           onClick={() => setPanelCollapsed(false)}
-          className="absolute top-1/2 -translate-y-1/2 left-0 z-30 w-1.5 h-12 bg-slate-800 text-white rounded-r-md shadow-lg border-r border-t border-b border-slate-700 hover:bg-slate-700 transition-colors flex items-center justify-center"
+          className="absolute top-1/2 -translate-y-1/2 left-0 z-30 w-6 h-12 bg-slate-800 text-white rounded-r-md shadow-lg border-r border-t border-b border-slate-700 hover:bg-slate-700 transition-colors flex items-center justify-center"
           aria-label="サイドパネルを展開する"
           title="サイドパネルを展開する"
         >
@@ -208,10 +208,10 @@ export function SidePanel({ nodes, edges, rawNodes, rawEdges, onNodeSelect }: Si
       {/* Panel - only show when searching or node selected */}
       {showPanel && (
         <aside className="absolute top-0 left-0 w-96 h-full bg-slate-800 shadow-lg flex flex-col border-r border-slate-700">
-          {/* Collapse button - on the right edge of panel, vertically centered, edge style */}
+          {/* Collapse button - outside the right edge of panel, vertically centered, edge style */}
           <button
             onClick={() => setPanelCollapsed(true)}
-            className="absolute top-1/2 -translate-y-1/2 right-0 z-30 w-1.5 h-12 bg-slate-800 text-white rounded-r-md shadow-lg border-r border-t border-b border-slate-700 hover:bg-slate-700 transition-colors flex items-center justify-center"
+            className="absolute top-1/2 -translate-y-1/2 -right-6 z-30 w-6 h-12 bg-slate-800 text-white rounded-r-md shadow-lg border-r border-t border-b border-slate-700 hover:bg-slate-700 transition-colors flex items-center justify-center"
             aria-label="サイドパネルを折りたたむ"
             title="サイドパネルを折りたたむ"
           >

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -36,6 +36,7 @@ export const useStore = create<StoreState>()(
           selectedNodeId: nodeId,
           selectedNodeData: nodeData ?? null,
           isInfoPanelOpen: nodeId !== null,
+          isPanelCollapsed: false, // Auto-expand on selection
         }),
       clearSelection: () =>
         set({
@@ -46,11 +47,13 @@ export const useStore = create<StoreState>()(
 
       // UI state
       isInfoPanelOpen: false,
+      isPanelCollapsed: false,
       activeTab: 'basic' as InfoPanelTab,
       tooltipPosition: null,
       tooltipContent: null,
       openInfoPanel: () => set({ isInfoPanelOpen: true }),
       closeInfoPanel: () => set({ isInfoPanelOpen: false }),
+      setPanelCollapsed: (collapsed: boolean) => set({ isPanelCollapsed: collapsed }),
       setActiveTab: (tab: InfoPanelTab) => set({ activeTab: tab }),
       showTooltip: (x: number, y: number, content: string) =>
         set({ tooltipPosition: { x, y }, tooltipContent: content }),

--- a/src/types/store.ts
+++ b/src/types/store.ts
@@ -35,11 +35,13 @@ export interface StoreState {
 
   // UI state
   isInfoPanelOpen: boolean
+  isPanelCollapsed: boolean
   activeTab: InfoPanelTab
   tooltipPosition: { x: number; y: number } | null
   tooltipContent: string | null
   openInfoPanel: () => void
   closeInfoPanel: () => void
+  setPanelCollapsed: (collapsed: boolean) => void
   setActiveTab: (tab: InfoPanelTab) => void
   showTooltip: (x: number, y: number, content: string) => void
   hideTooltip: () => void


### PR DESCRIPTION
## 改善内容

左パネルのUXを3点改善しました。

### 1. タイトルホバーでフルネーム表示

省略されているタイトルにマウスホバーすると、`title` 属性でフルネームを表示します。

```tsx
<h2 className="text-lg font-semibold text-white truncate" title={selectedNode.name}>
  {selectedNode.name}
</h2>
```

### 2. 階層パス（親ノード情報）の改行位置調整

階層パス（府省→局→課→事業）の改行位置を改善:
- `break-words` で自然な位置で改行
- 各要素を `inline-block` にして矢印と要素を一緒に保持
- 以前より右側まで表示してから改行

```tsx
<p className="text-sm text-slate-400 mt-1 break-words">
  {selectedNode.metadata.hierarchyPath.map((path, index) => (
    <span key={index} className="inline-block">
      {index > 0 && <span className="mx-1">→</span>}
      <span>{path}</span>
    </span>
  ))}
</p>
```

### 3. パネルのコンパクト表示

検索ボックスのみの状態を簡潔に:
- **検索中またはノード選択時**: `w-96` (384px) - フル幅
- **待機状態**: `w-80` (320px) - コンパクト幅
- `transition-all` でスムーズなアニメーション
- 検索履歴と空の状態表示を削除（シンプル化）

```tsx
const showPanel = query.trim() || selectedNode

<aside className={`... ${showPanel ? 'w-96' : 'w-80'}`}>
```

## 変更ファイル

- `src/components/SidePanel.tsx`
  - タイトルに `title` 属性追加
  - 階層パスに `break-words` と `inline-block` 追加
  - パネル幅を動的に変更
  - 検索履歴機能と空状態表示を削除（-49行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side panel is now a collapsible overlay with a right-edge toggle and auto-expands when an item is selected.

* **UI Improvements**
  * Panel only appears for active queries or selections; search input is shown and expanded only when panel is open.
  * Node details, tabs (Basic/Recipients/Flow), results and actions reorganized inside the overlay with updated styling.

* **Removals**
  * Search history feature and its related UI elements removed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->